### PR TITLE
Provide for alternate slack URLs

### DIFF
--- a/src/slack_hooks/service/pagerduty.clj
+++ b/src/slack_hooks/service/pagerduty.clj
@@ -10,6 +10,9 @@
 (def pagerduty-avatar
   (System/getenv "PAGERDUTY_AVATAR"))
 
+(def pagerduty-slack-url
+  (System/getenv "PAGERDUTY_SLACK_URL"))
+
 (defn incident-color
   [incident-type]
   (case incident-type
@@ -105,7 +108,8 @@
   (doseq [message (-> request :body :messages)
           :let [slack (pagerduty-message->slack message)]]
     (prn "message:" message)
-    (slack/notify {:username    pagerduty-username
+    (slack/notify {:slack-url   (or (-> request :params :slack-url) pagerduty-slack-url)
+                   :username    pagerduty-username
                    :icon_url    pagerduty-avatar
                    :attachments [{:pretext (:title slack)
                                   :text    (:description slack)

--- a/src/slack_hooks/service/tender.clj
+++ b/src/slack_hooks/service/tender.clj
@@ -18,6 +18,9 @@
     (System/getenv "TENDER_COLOR")
     "#6DB4D3"))
 
+(def tender-slack-url
+  (System/getenv "TENDER_SLACK_URL"))
+
 (defn truncate-string
   "Take a string and limit it to a certain number of characters"
   [string limit]
@@ -108,7 +111,8 @@
   "Accepts an HTTP request from a Tender webhook and reports the details to a
   Slack webhook."
   [request]
-  (slack/notify {:username tender-username
-                 :icon_url tender-avatar
+  (slack/notify {:slack-url   (or (-> request :params :slack_url) tender-slack-url)
+                 :username    tender-username
+                 :icon_url    tender-avatar
                  :attachments [{:text (formatted-message request)
                                 :color tender-color}]}))

--- a/src/slack_hooks/service/travis.clj
+++ b/src/slack_hooks/service/travis.clj
@@ -11,7 +11,10 @@
     "travis-ci"))
 
 (def travis-avatar
-    (System/getenv "TRAVIS_AVATAR"))
+  (System/getenv "TRAVIS_AVATAR"))
+
+(def travis-slack-url
+  (System/getenv "TRAVIS_SLACK_URL"))
 
 (defn status-color
   [request]
@@ -77,8 +80,9 @@
 
 
 (defn travis [request]
-  (prn (-> request :params :payload))
-  (slack/notify {:username travis-username
-                 :icon_url travis-avatar
+  ; (prn (-> request :params :payload))
+  (slack/notify {:slack-url   (or (-> request :params :slack_url) travis-slack-url)
+                 :username    travis-username
+                 :icon_url    travis-avatar
                  :attachments [{:text (travis-format request)
                                :color (status-color request)}]}))

--- a/src/slack_hooks/slack.clj
+++ b/src/slack_hooks/slack.clj
@@ -16,8 +16,10 @@
     text))
 
 (defn notify [data]
-  (client/post slack-url
-    {:insecure? true  ;; Temporary until we're able to figure out how to
-                      ;; properly validate Slack's SSL cert.
-     :content-type :json
-     :form-params data}))
+  (let [post-url (or (:slack-url data) slack-url)
+        slack-data (dissoc data :slack-url)]
+    (client/post post-url
+                 {:insecure? true  ;; Temporary until we're able to figure out how to
+                  ;; properly validate Slack's SSL cert.
+                  :content-type :json
+                  :form-params slack-data})))


### PR DESCRIPTION
This makes it easy to have different services go into different channels.